### PR TITLE
Add Product Change History Retrieval with Hibernate Envers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,14 @@
 			<artifactId>opencsv</artifactId>
 			<version>5.7.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-envers</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-envers</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/hasib/ProductParser/controller/ProductController.java
+++ b/src/main/java/com/hasib/ProductParser/controller/ProductController.java
@@ -3,6 +3,7 @@ package com.hasib.ProductParser.controller;
 
 import com.hasib.ProductParser.dto.ApiResponse;
 import com.hasib.ProductParser.dto.ProductUploadResponseDto;
+import com.hasib.ProductParser.model.ChangeHistory;
 import com.hasib.ProductParser.model.Product;
 import com.hasib.ProductParser.service.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,19 @@ public class ProductController {
                         "File uploaded successfully!",
                         HttpStatus.OK.value(),
                         responseDto
+                )
+        );
+    }
+
+    @GetMapping("/change-histories")
+    public ResponseEntity<ApiResponse<List<ChangeHistory>>> getChangeHistories() {
+
+        List<ChangeHistory> changeHistories = productService.getChangeHistories();
+        return ResponseEntity.ok(
+                new ApiResponse<>(
+                        "Product change histories retrieved successfully.",
+                        HttpStatus.OK.value(),
+                        changeHistories
                 )
         );
     }

--- a/src/main/java/com/hasib/ProductParser/model/ChangeHistory.java
+++ b/src/main/java/com/hasib/ProductParser/model/ChangeHistory.java
@@ -1,0 +1,25 @@
+package com.hasib.ProductParser.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ChangeHistory extends Product {
+
+    private List<Product> histories;
+
+    public ChangeHistory(Product product, List<Product> histories){
+        this.histories = histories;
+        this.setId(product.getId());
+        this.setDescription(product.getDescription());
+        this.setQuantity(product.getQuantity());
+        this.setPrice(product.getPrice());
+        this.setSku(product.getSku());
+        this.setTitle(product.getTitle());
+        this.setCreatedDate(product.getCreatedDate());
+        this.setLastModifiedDate(product.getLastModifiedDate());
+    }
+}

--- a/src/main/java/com/hasib/ProductParser/model/Product.java
+++ b/src/main/java/com/hasib/ProductParser/model/Product.java
@@ -2,6 +2,7 @@ package com.hasib.ProductParser.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.envers.Audited;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Audited
 @EntityListeners(AuditingEntityListener.class)
 public class Product {
     @Id

--- a/src/main/java/com/hasib/ProductParser/repository/ProductRepository.java
+++ b/src/main/java/com/hasib/ProductParser/repository/ProductRepository.java
@@ -2,9 +2,10 @@ package com.hasib.ProductParser.repository;
 
 import com.hasib.ProductParser.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.history.RevisionRepository;
 
 import java.util.UUID;
 
-public interface ProductRepository extends JpaRepository<Product, UUID> {
+public interface ProductRepository extends RevisionRepository<Product, UUID, Integer>, JpaRepository<Product, UUID> {
 
 }

--- a/src/main/java/com/hasib/ProductParser/service/ProductService.java
+++ b/src/main/java/com/hasib/ProductParser/service/ProductService.java
@@ -10,6 +10,8 @@ import com.hasib.ProductParser.service.parser.FileParserFactory;
 import com.opencsv.exceptions.CsvValidationException;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.history.Revision;
+import org.springframework.data.history.Revisions;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -104,6 +106,21 @@ public class ProductService {
     }
 
     public List<ChangeHistory> getChangeHistories() {
-        return null;
+        List<Product> products = productRepository.findAll();
+        List<ChangeHistory> changeHistories = new ArrayList<>();
+
+        for (Product product : products) {
+
+            Revisions<Integer, Product> revisions = productRepository.findRevisions(product.getId());
+            List<Product> histories = new ArrayList<>();
+
+            for (Revision<Integer, Product> revision : revisions) {
+                histories.add(revision.getEntity());
+            }
+
+            ChangeHistory changeHistory = new ChangeHistory(product, histories);
+            changeHistories.add(changeHistory);
+        }
+        return changeHistories;
     }
 }

--- a/src/main/java/com/hasib/ProductParser/service/ProductService.java
+++ b/src/main/java/com/hasib/ProductParser/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.hasib.ProductParser.service;
 
 import com.hasib.ProductParser.dto.ProductUploadResponseDto;
+import com.hasib.ProductParser.model.ChangeHistory;
 import com.hasib.ProductParser.model.Product;
 import com.hasib.ProductParser.model.enums.FileType;
 import com.hasib.ProductParser.repository.ProductRepository;
@@ -100,5 +101,9 @@ public class ProductService {
 
     public List<Product> getAllProducts() {
         return productRepository.findAll();
+    }
+
+    public List<ChangeHistory> getChangeHistories() {
+        return null;
     }
 }

--- a/src/test/java/com/hasib/ProductParser/unitTest/controller/ProductControllerTest.java
+++ b/src/test/java/com/hasib/ProductParser/unitTest/controller/ProductControllerTest.java
@@ -2,6 +2,7 @@ package com.hasib.ProductParser.unitTest.controller;
 
 import com.hasib.ProductParser.controller.ProductController;
 import com.hasib.ProductParser.dto.ProductUploadResponseDto;
+import com.hasib.ProductParser.model.ChangeHistory;
 import com.hasib.ProductParser.model.Product;
 import com.hasib.ProductParser.service.ProductService;
 import org.junit.jupiter.api.Test;
@@ -103,4 +104,28 @@ public class ProductControllerTest {
                 );
     }
 
+    @Test
+    public void ProductController_getChangeHistories_ShouldReturnChangeHistories() throws Exception {
+        Product oldProduct = new Product(UUID.randomUUID(), "SKU1", "Product 1", 10.0, 5, "Old Description", null, null);
+        Product newProduct = new Product(UUID.randomUUID(), "SKU1", "Product 1", 15.0, 3, "New Description", null, null);
+
+        ChangeHistory changeHistory1 = new ChangeHistory(newProduct, List.of(oldProduct,newProduct));
+        List<ChangeHistory> changeHistories = List.of(changeHistory1);
+
+        when(productService.getChangeHistories()).thenReturn(changeHistories);
+
+        ResultActions resultActions = mockMvc.perform(get("/api/products/change-histories"))
+                .andDo(print())
+                .andExpectAll(
+                        status().isOk(),
+                        MockMvcResultMatchers.jsonPath("$.message").value("Product change histories retrieved successfully."),
+                        MockMvcResultMatchers.jsonPath("$.statusCode").value(HttpStatus.OK.value()),
+                        MockMvcResultMatchers.jsonPath("$.data", hasSize(1)),
+                        MockMvcResultMatchers.jsonPath("$.data[0].histories",hasSize(2)),
+                        MockMvcResultMatchers.jsonPath("$.data[0].histories[0].price").value(10),
+                        MockMvcResultMatchers.jsonPath("$.data[0].histories[1].price").value(15),
+                        MockMvcResultMatchers.jsonPath("$.data[0].histories[0].quantity").value(5),
+                        MockMvcResultMatchers.jsonPath("$.data[0].histories[1].quantity").value(3)
+                );
+    }
 }


### PR DESCRIPTION
- Added ChangeHistory.java to store product change histories.
- Implemented /change-histories endpoint in ProductController to retrieve product histories.
- Added ProductController_getChangeHistories_ShouldReturnChangeHistories test in ProductControllerTest.
- Added Hibernate Envers for auditing with @Audited annotation in Product.
- Updated ProductRepository to extend RevisionRepository for revision tracking.
- Implemented getChangeHistories method in ProductService.